### PR TITLE
Add multiple mappings per sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.5
+
+## Improvements
+
+* Multiple mappings support
+
 # v1.0.4
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Migration website: https://pierosavi.github.io/imageit-migration/
 * Links on sensors
 * Change sensors text and background color
 * Value mapping system
+* Multiple mappings for sensor - Thanks [@lukaszsamson](https://github.com/lukaszsamson)
 
 ## What features are missing from the previous version?
 * Font awesome icons in sensor name
 * Font size configurable per sensor
-* Multiple mappings for sensor
 
 They will come in the next versions, if requested
 

--- a/src/ImageItPanel.tsx
+++ b/src/ImageItPanel.tsx
@@ -6,6 +6,7 @@ import _ from 'lodash';
 // import { stylesFactory, useTheme } from '@grafana/ui';
 import { stylesFactory, useTheme } from '@grafana/ui';
 import { Sensor } from './Sensor';
+import { Mapping } from './types/Mapping';
 import SensorType from './types/Sensor';
 
 interface Props extends PanelProps<SimpleOptions> {}
@@ -93,14 +94,16 @@ export const ImageItPanel: React.FC<Props> = ({
               value = fieldDisplay.display.numeric;
             }
 
-            // Get mapping by id || undefined
-            const mapping = sensor.mappingId ? mappings.find(mapping => sensor.mappingId === mapping.id) : undefined;
+            // Get mappings by ids
+            const sensorMappings: Mapping[] = sensor.mappingIds
+              .map((mappingId) => mappings.find((mapping: Mapping) => mappingId === mapping.id))
+              .filter((mapping) => typeof mapping !== "undefined") as Mapping[];
 
             return (
               <Sensor
                 draggable={lockSensors}
                 sensor={sensor}
-                mapping={mapping}
+                mappings={sensorMappings}
                 index={index}
                 link={replaceVariables(sensor.link)}
                 name={replaceVariables(sensor.name)}

--- a/src/ImageItPanel.tsx
+++ b/src/ImageItPanel.tsx
@@ -96,8 +96,8 @@ export const ImageItPanel: React.FC<Props> = ({
 
             // Get mappings by ids
             const sensorMappings: Mapping[] = sensor.mappingIds
-              .map((mappingId) => mappings.find((mapping: Mapping) => mappingId === mapping.id))
-              .filter((mapping) => typeof mapping !== "undefined") as Mapping[];
+              .map(mappingId => mappings.find((mapping: Mapping) => mappingId === mapping.id))
+              .filter(mapping => typeof mapping !== 'undefined') as Mapping[];
 
             return (
               <Sensor

--- a/src/Sensor.tsx
+++ b/src/Sensor.tsx
@@ -63,6 +63,8 @@ export const Sensor: React.FC<Props> = (props: Props) => {
     if (isOverrode) {
       // Assume that mapping values perfectly matches sensor fields, it's not covered by typescript
       sensor = _.merge(sensor, mapping.values);
+      // Stop at first valid mapping
+      break;
     }
   }
 

--- a/src/Sensor.tsx
+++ b/src/Sensor.tsx
@@ -10,7 +10,7 @@ import { formattedValueToString, getValueFormat } from '@grafana/data';
 
 type Props = {
   sensor: SensorType;
-  mapping: Mapping | undefined;
+  mappings: Mapping[];
   draggable: boolean;
   index: number;
   link: string;
@@ -33,7 +33,7 @@ const percToPx = (perc: number, size: number): number => {
 
 export const Sensor: React.FC<Props> = (props: Props) => {
   // const theme = useTheme();
-  const { draggable, imageDimensions, onPositionChange, index, link, name, mapping, value } = props;
+  const { draggable, imageDimensions, onPositionChange, index, link, name, mappings, value } = props;
   let sensor = _.clone(props.sensor);
 
   const styles = getStyles();
@@ -54,14 +54,16 @@ export const Sensor: React.FC<Props> = (props: Props) => {
     y: percToPx(sensor.position.y, imageDimensions.height),
   };
 
-  const mappingOperator = MappingOperators.find(mappingOperator => mapping?.operator === mappingOperator.id);
+  for(let mapping of mappings) {
+    const mappingOperator = MappingOperators.find(mappingOperator => mapping.operator === mappingOperator.id);
 
-  // Apply mapping function if it satisfies requirements
-  const isOverrode = mappingOperator?.function(value, mapping!.compareTo);
+    // Apply mapping function if it satisfies requirements
+    const isOverrode = mappingOperator?.function(value, mapping.compareTo);
 
-  if (isOverrode) {
-    // Assume that mapping values perfectly matches sensor fields, it's not covered by typescript
-    sensor = _.merge(sensor, mapping!.values);
+    if (isOverrode) {
+      // Assume that mapping values perfectly matches sensor fields, it's not covered by typescript
+      sensor = _.merge(sensor, mapping.values);
+    }
   }
 
   // Get and apply unit type formatter

--- a/src/Sensor.tsx
+++ b/src/Sensor.tsx
@@ -54,7 +54,7 @@ export const Sensor: React.FC<Props> = (props: Props) => {
     y: percToPx(sensor.position.y, imageDimensions.height),
   };
 
-  for(let mapping of mappings) {
+  for (let mapping of mappings) {
     const mappingOperator = MappingOperators.find(mappingOperator => mapping.operator === mappingOperator.id);
 
     // Apply mapping function if it satisfies requirements

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Input, ColorPicker, Switch, Field, HorizontalGroup, IconButton, UnitPicker, Button } from '@grafana/ui';
+import {
+  Input,
+  ColorPicker,
+  Switch,
+  Field,
+  HorizontalGroup,
+  IconButton,
+  UnitPicker,
+  Button,
+  TagsInput,
+} from '@grafana/ui';
 import Sensor from '../types/Sensor';
 
 import produce from 'immer';
@@ -52,18 +62,13 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
       </Field>
       {/* </HorizontalGroup> */}
 
-      <Field
-        label="Mapping ID"
-        description="Paste here comma-separated IDs of the mappings you want to use for this sensor"
-      >
-        <Input
-          value={sensor.mappingIds.join(', ')}
-          onChange={event => {
+      <Field label="Mapping IDs" description="Select IDs of mappings you want to use for this sensor">
+        <TagsInput
+          // @ts-ignore - will be removed when upgrading grafana/ui
+          placeholder="Add a new mapping"
+          tags={sensor.mappingIds}
+          onChange={(mappingIds: string[]) => {
             updateSensor(sensor => {
-              const mappingIds = event.currentTarget.value
-                .split(',')
-                .map(mappingId => mappingId.trim())
-                .filter(mappingId => mappingId !== '');
               sensor.mappingIds = mappingIds;
             });
           }}

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -62,7 +62,10 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
       </Field>
       {/* </HorizontalGroup> */}
 
-      <Field label="Mapping IDs" description="Select IDs of mappings you want to use for this sensor. First valid mapping will be applied.">
+      <Field
+        label="Mapping IDs"
+        description="Select IDs of mappings you want to use for this sensor. First valid mapping will be applied."
+      >
         <TagsInput
           // @ts-ignore - will be removed when upgrading grafana/ui
           placeholder="Add a new mapping"

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -52,12 +52,16 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
       </Field>
       {/* </HorizontalGroup> */}
 
-      <Field label="Mapping ID" description="Past here the ID of the mapping you want to use for this sensor">
+      <Field label="Mapping ID" description="Paste here comma-separated IDs of the mappings you want to use for this sensor">
         <Input
-          value={sensor.mappingId}
+          value={sensor.mappingIds.join(", ")}
           onChange={event => {
             updateSensor(sensor => {
-              sensor.mappingId = event.currentTarget.value;
+              const mappingIds = event.currentTarget.value
+                .split(",")
+                .map((mappingId) => mappingId.trim())
+                .filter((mappingId) => mappingId != "");
+              sensor.mappingIds = mappingIds;
             });
           }}
         />

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -52,15 +52,18 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
       </Field>
       {/* </HorizontalGroup> */}
 
-      <Field label="Mapping ID" description="Paste here comma-separated IDs of the mappings you want to use for this sensor">
+      <Field
+        label="Mapping ID"
+        description="Paste here comma-separated IDs of the mappings you want to use for this sensor"
+      >
         <Input
-          value={sensor.mappingIds.join(", ")}
+          value={sensor.mappingIds.join(', ')}
           onChange={event => {
             updateSensor(sensor => {
               const mappingIds = event.currentTarget.value
-                .split(",")
-                .map((mappingId) => mappingId.trim())
-                .filter((mappingId) => mappingId != "");
+                .split(',')
+                .map(mappingId => mappingId.trim())
+                .filter(mappingId => mappingId !== '');
               sensor.mappingIds = mappingIds;
             });
           }}

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -62,7 +62,7 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
       </Field>
       {/* </HorizontalGroup> */}
 
-      <Field label="Mapping IDs" description="Select IDs of mappings you want to use for this sensor">
+      <Field label="Mapping IDs" description="Select IDs of mappings you want to use for this sensor. First valid mapping will be applied.">
         <TagsInput
           // @ts-ignore - will be removed when upgrading grafana/ui
           placeholder="Add a new mapping"

--- a/src/customEditors/EditorSensorList.tsx
+++ b/src/customEditors/EditorSensorList.tsx
@@ -27,7 +27,7 @@ const defaultNewSensor: Sensor = {
     x: 50,
     y: 50,
   },
-  mappingId: '',
+  mappingIds: [],
   unit: undefined,
   decimals: 2,
   valueBlink: false,

--- a/src/migrationHandler.test.ts
+++ b/src/migrationHandler.test.ts
@@ -1,0 +1,33 @@
+import { migrationHandler, OldSensorType } from './migrationHandler';
+import { SimpleOptions } from './types/SimpleOptions';
+import { FieldConfigSource, PanelModel } from '@grafana/data';
+
+describe('Migration handler', () => {
+  describe('when migrating to a newer version', () => {
+    it('should change mappingId correctly', () => {
+      const mappingId = 'myMappingId';
+      const panel: PanelModel<SimpleOptions> = {
+        id: 1,
+        fieldConfig: ({} as unknown) as FieldConfigSource,
+        options: {
+          forceImageRefresh: false,
+          imageUrl: 'http://foo.bar/image.png',
+          lockSensors: false,
+          sensorsTextSize: 10,
+          mappings: [],
+          sensors: [
+            {
+              mappingId: mappingId,
+            },
+          ] as OldSensorType[],
+        },
+      };
+
+      const result = migrationHandler(panel);
+
+      // @ts-ignore
+      expect(result.sensors[0].mappingId).toBeUndefined();
+      expect(result.sensors[0].mappingIds).toStrictEqual([mappingId]);
+    });
+  });
+});

--- a/src/migrationHandler.ts
+++ b/src/migrationHandler.ts
@@ -1,0 +1,27 @@
+import { PanelModel } from '@grafana/data';
+import { SimpleOptions } from './types/SimpleOptions';
+import Sensor from './types/Sensor';
+
+export type OldSensorType = Sensor & {
+  mappingId?: string;
+};
+
+export const migrationHandler = (panel: PanelModel<SimpleOptions>) => {
+  // const previousVersion = parseFloat(panel.pluginVersion || '1.0.0');
+  let options = panel.options;
+
+  const sensors = (options.sensors || []) as OldSensorType[];
+
+  if (sensors) {
+    sensors.map(sensor => {
+      if (sensor.mappingId) {
+        sensor.mappingIds = [sensor.mappingId];
+        delete sensor.mappingId;
+      } else {
+        sensor.mappingIds = [];
+      }
+    });
+  }
+
+  return options;
+};

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -4,57 +4,60 @@ import { SimpleOptions } from './types/SimpleOptions';
 import { ImageItPanel } from './ImageItPanel';
 import { EditorSensorList } from 'customEditors/EditorSensorList';
 import { EditorMappingList } from 'customEditors/EditorMappingList';
+import { migrationHandler } from './migrationHandler';
 
-export const plugin = new PanelPlugin<SimpleOptions>(ImageItPanel).setPanelOptions(builder => {
-  const panelOptionsBuilder = builder
-    .addTextInput({
-      path: 'imageUrl',
-      name: 'Image URL',
-      description: 'URL of background image',
-      defaultValue: 'https://i.ibb.co/tLXrjb6/imageit.png',
-    })
-    .addBooleanSwitch({
-      path: 'forceImageRefresh',
-      name: 'Force image refresh',
-      description:
-        'Enable to force image refresh when data changes. Use only if cache control is not possible. Check readme on Github if not sure.',
-      defaultValue: false,
-    })
-    .addBooleanSwitch({
-      path: 'lockSensors',
-      name: 'Lock sensors movement',
-      defaultValue: false,
-      category: ['Sensors'],
-    })
-    .addNumberInput({
-      path: 'sensorsTextSize',
-      name: 'Sensors text size',
-      description: 'Default sensors text size. Default 10.',
-      defaultValue: 10,
-      category: ['Sensors'],
-    })
-    .addCustomEditor({
-      id: 'sensors',
-      path: 'sensors',
-      name: 'Sensors',
-      description: 'List of sensors',
-      category: ['Sensors'],
-      defaultValue: [],
-      editor: props => {
-        return <EditorSensorList sensors={props.value} onChange={props.onChange} />;
-      },
-    })
-    .addCustomEditor({
-      id: 'mappings',
-      path: 'mappings',
-      name: 'Mappings',
-      description: 'List of mappings',
-      category: ['Mappings'],
-      defaultValue: [],
-      editor: props => {
-        return <EditorMappingList mappings={props.value} onChange={props.onChange} />;
-      },
-    });
+export const plugin = new PanelPlugin<SimpleOptions>(ImageItPanel)
+  .setMigrationHandler(migrationHandler)
+  .setPanelOptions(builder => {
+    const panelOptionsBuilder = builder
+      .addTextInput({
+        path: 'imageUrl',
+        name: 'Image URL',
+        description: 'URL of background image',
+        defaultValue: 'https://i.ibb.co/tLXrjb6/imageit.png',
+      })
+      .addBooleanSwitch({
+        path: 'forceImageRefresh',
+        name: 'Force image refresh',
+        description:
+          'Enable to force image refresh when data changes. Use only if cache control is not possible. Check readme on Github if not sure.',
+        defaultValue: false,
+      })
+      .addBooleanSwitch({
+        path: 'lockSensors',
+        name: 'Lock sensors movement',
+        defaultValue: false,
+        category: ['Sensors'],
+      })
+      .addNumberInput({
+        path: 'sensorsTextSize',
+        name: 'Sensors text size',
+        description: 'Default sensors text size. Default 10.',
+        defaultValue: 10,
+        category: ['Sensors'],
+      })
+      .addCustomEditor({
+        id: 'sensors',
+        path: 'sensors',
+        name: 'Sensors',
+        description: 'List of sensors',
+        category: ['Sensors'],
+        defaultValue: [],
+        editor: props => {
+          return <EditorSensorList sensors={props.value} onChange={props.onChange} />;
+        },
+      })
+      .addCustomEditor({
+        id: 'mappings',
+        path: 'mappings',
+        name: 'Mappings',
+        description: 'List of mappings',
+        category: ['Mappings'],
+        defaultValue: [],
+        editor: props => {
+          return <EditorMappingList mappings={props.value} onChange={props.onChange} />;
+        },
+      });
 
-  return panelOptionsBuilder;
-});
+    return panelOptionsBuilder;
+  });

--- a/src/types/Sensor.ts
+++ b/src/types/Sensor.ts
@@ -15,7 +15,7 @@ type Sensor = {
     x: number;
     y: number;
   };
-  mappingId: string;
+  mappingIds: string[];
   unit: string | undefined;
   decimals: number;
 };


### PR DESCRIPTION
I'm trying to upgrade to new version of this plugin and I've found this feature missing. I took the minimal approach to allow setting multiple mappings while keeping backward compatibility with recent versions. Setting single mapping ID should work as before and now multiple IDs can be also set as a comma-separated list.