### PR TITLE
fix: remove *enableNamedColors* from ColorPicker attribute list

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "emotion": "10.0.27"
   },
   "engines": {
-    "node": ">=12 <13"
+    "node": ">=12"
   },
   "dependencies": {
     "immer": "9.0.5",

--- a/src/customEditors/EditorMappingItem.tsx
+++ b/src/customEditors/EditorMappingItem.tsx
@@ -83,7 +83,6 @@ export const EditorMappingItem: React.FC<Props> = (props: Props) => {
               mapping.values.fontColor = color;
             });
           }}
-          enableNamedColors
         >
           {({ ref, showColorPicker, hideColorPicker }) => (
             <Button ref={ref} onMouseLeave={hideColorPicker} onClick={showColorPicker} variant="secondary">
@@ -101,7 +100,6 @@ export const EditorMappingItem: React.FC<Props> = (props: Props) => {
               mapping.values.backgroundColor = color;
             });
           }}
-          enableNamedColors
         >
           {({ ref, showColorPicker, hideColorPicker }) => (
             <Button ref={ref} onMouseLeave={hideColorPicker} onClick={showColorPicker} variant="secondary">

--- a/src/customEditors/EditorSensorItem.tsx
+++ b/src/customEditors/EditorSensorItem.tsx
@@ -120,7 +120,6 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
               sensor.fontColor = color;
             });
           }}
-          enableNamedColors
         >
           {({ ref, showColorPicker, hideColorPicker }) => (
             <Button ref={ref} onMouseLeave={hideColorPicker} onClick={showColorPicker} variant="secondary">
@@ -138,7 +137,6 @@ export const EditorSensorItem: React.FC<Props> = (props: Props) => {
               sensor.backgroundColor = color;
             });
           }}
-          enableNamedColors
         >
           {({ ref, showColorPicker, hideColorPicker }) => (
             <Button ref={ref} onMouseLeave={hideColorPicker} onClick={showColorPicker} variant="secondary">


### PR DESCRIPTION
## remove node version constraint *<13*

node version >=14 is widely used now, no need to constraint to *<13*
i build plugin with both v16.5.0 & v14.17.4, all works fine

## use RGB instead of Grafana defined color names

on Grafana v8.*, both font color and background color not show after selecting pre-defined colors, neither sensor rendering

![imageit-color-picker](https://user-images.githubusercontent.com/16284900/144196984-4aff56df-fe0a-4a7d-a9b9-2e898479614b.png)

once add `enableNamedColors` attribute, those Grafana pre-defined color names(e.g., `light-green`, `semi-dark-red`) can not be recognized by CSS, so ColorDot  and Sensor will not render font/background color

![color-picker](https://user-images.githubusercontent.com/16284900/144197386-6d725a1a-50df-4b51-8d28-1b8b7b4d9fe9.png)

`fontColor` and `backgroundColor` can not be rendered for pre-defined color names.

![enableNamedColors](https://user-images.githubusercontent.com/16284900/144198246-c18aba1b-737c-423e-838f-464e24bf85cd.png)

